### PR TITLE
Correctif CSS Header list: Ajout systématique de la marge entre éléments

### DIFF
--- a/themes/hugo-ttl/static/style.css
+++ b/themes/hugo-ttl/static/style.css
@@ -87,4 +87,5 @@ li.header a {
     display: inline-block;
     background: #5F5A50;
     color: #FFFFFF;
+    margin-right: 5px;
 }


### PR DESCRIPTION
La différence entre le visuel en localhost et online est dûe au fait que online on lance le serveur hugo avec l'option --minify. Sans cette option, hugo rajoute des espaces non voulus dans le html généré. 

L'évolution du style.css permet de faire porter cette marge souhaitée entre les deux boutons de la navbar par le CSS et non plus par un effet de bord de génération de hugo.